### PR TITLE
the part that returns encryptedId

### DIFF
--- a/Riot-Crawler/src/main/java/Team10/RiotCrawler/api/RiotApiClient.java
+++ b/Riot-Crawler/src/main/java/Team10/RiotCrawler/api/RiotApiClient.java
@@ -9,7 +9,7 @@ import org.springframework.web.client.RestTemplate;
 
 @Service
 public class RiotApiClient {
-    private final String api_key = "RGAPI-ec5a5a65-88c8-4b60-90b7-6f41aedc7280";
+    private final String api_key = "RGAPI-20c898f3-f039-473f-a8a0-ad9d4e5505ed";
     private final String OpenRiotUrl_getEncryptedId = "https://kr.api.riotgames.com/lol/summoner/v4/summoners/by-name/{summonerName}?api_key={api_key}";
     private final String OpenRiotUrl_getSummonerInfo = "https://kr.api.riotgames.com/lol/league/v4/entries/by-summoner/{encryptedId}?api_key={api_key}";
 

--- a/Riot-Crawler/src/main/java/Team10/RiotCrawler/controller/RiotController.java
+++ b/Riot-Crawler/src/main/java/Team10/RiotCrawler/controller/RiotController.java
@@ -2,9 +2,11 @@ package Team10.RiotCrawler.controller;
 
 
 import Team10.RiotCrawler.domain.LeaguePosition;
+import Team10.RiotCrawler.domain.SummonerInfo;
 import Team10.RiotCrawler.service.RiotService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -13,10 +15,11 @@ public class RiotController
     @Autowired
     RiotService riotService;
 
-    @GetMapping("/riot-crawler/leagueposition/{summonername}")
-    public LeaguePosition getLeaguePosition(String summonerName)
+    // LeaguePosition을 return
+    @GetMapping("/riot-crawler/leagueposition/{summonerName}")
+    public String getLeaguePosition(@PathVariable String summonerName)
     {
-        return riotService.getLeaguePositionBySummonerName(summonerName);
+        //return riotService.getLeaguePositionBySummonerName(summonerName); // LeaguePosition을 리턴
+        return riotService.getEncryptedSummonerId(summonerName); // 테스트로 encryptedId를 리턴.
     }
-
 }

--- a/Riot-Crawler/src/main/java/Team10/RiotCrawler/service/RiotService.java
+++ b/Riot-Crawler/src/main/java/Team10/RiotCrawler/service/RiotService.java
@@ -20,7 +20,9 @@ public class RiotService {
     }
 
     public LeaguePosition getLeaguePositionBySummonerName(String summonerName) {
+
         String encryptedSummonerId = getEncryptedSummonerId(summonerName);
-        return leaguePositionRepository.findLeaguePosition(encryptedSummonerId);
+        return riotApiClient.requestSummonerInfo(encryptedSummonerId);
+        //return leaguePositionRepository.findLeaguePosition(encryptedSummonerId);
     }
 }

--- a/Riot-Crawler/src/main/resources/application.properties
+++ b/Riot-Crawler/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-
+server.port=8082


### PR DESCRIPTION
RiotController에서 URL 오타 수정, @PathVariable 없어서 추가 시킴.
LeaguePosition을 리턴 하기 전, encryptedId를 리턴 해주는 곳까지 구현함.
이후 repository를 구현한 후 RiotController에서 getLeaguePosition 메소드의 리턴 타입을 바꿔줘야 함.